### PR TITLE
[feat]: 전화번호 중복여부에 따른 로그인 기능 추가 (#6)

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+togather

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,15 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,8 +4,8 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="GRADLE" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="Android Studio default JDK" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,4 +47,13 @@ dependencies {
 
     // lottie 적용을 위한 라이브러리 추가
     implementation "com.airbnb.android:lottie:6.0.1"
+
+// 안드로이드 앱과 서버 통신을 위한 Retrofit 라이브러리 추가
+    // https://mvnrepository.com/artifact/com.squareup.retrofit2/retrofit
+    implementation group: 'com.squareup.retrofit2', name: 'retrofit', version: '2.11.0'
+
+    // Gson 변환기 라이브러리
+    // https://mvnrepository.com/artifact/com.squareup.retrofit2/converter-gson
+    implementation group: 'com.squareup.retrofit2', name: 'converter-gson', version: '2.11.0'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!--  retrofit 통신을 위해 추가  -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,6 +14,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Togather"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".HandleAndStoreUserInformationPoliciesActivity"

--- a/app/src/main/java/com/project/togather/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/LoginActivity.java
@@ -74,7 +74,9 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     // 전화번호 중복 확인 메서드
-    private void checkPhoneNumber(String phoneNumber) {
+        private void checkPhoneNumber(String phoneNumber) {
+        // 전화번호 문자열 내 공백을 제거
+        phoneNumber = phoneNumber.replaceAll("\\s", "");
         Call<ResponseBody> call = userAPI.checkPhoneNumber(phoneNumber);
         call.enqueue(new Callback<ResponseBody>() {
             @Override
@@ -89,9 +91,9 @@ public class LoginActivity extends AppCompatActivity {
                             String json = responseBody.string();
                             JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
 
-                            if(jsonObject != null && jsonObject.has("result")) {
+                            if (jsonObject != null && jsonObject.has("result")) {
                                 String result = jsonObject.get("result").getAsString();
-                                if("1".equals(result)) {
+                                if ("1".equals(result)) {
                                     // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
                                     Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
                                     startActivity(intent);
@@ -108,15 +110,15 @@ public class LoginActivity extends AppCompatActivity {
                     } else {
                         // API 요청으로 받은 데이터가 null인 경우
                     }
-                }
-                else {
+                } else {
                     // 요청이 실패한 경우
                 }
             }
 
             @Override
             public void onFailure(Call<ResponseBody> call, Throwable throwable) {
-                // 네트워크 요청 오류
+                // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                new ToastWarning(getResources().getString(R.string.toast_server_error), LoginActivity.this);
             }
         });
     }

--- a/app/src/main/java/com/project/togather/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/LoginActivity.java
@@ -74,7 +74,7 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     // 전화번호 중복 확인 메서드
-        private void checkPhoneNumber(String phoneNumber) {
+    private void checkPhoneNumber(String phoneNumber) {
         // 전화번호 문자열 내 공백을 제거
         phoneNumber = phoneNumber.replaceAll("\\s", "");
         Call<ResponseBody> call = userAPI.checkPhoneNumber(phoneNumber);
@@ -93,16 +93,18 @@ public class LoginActivity extends AppCompatActivity {
 
                             if (jsonObject != null && jsonObject.has("result")) {
                                 String result = jsonObject.get("result").getAsString();
-                                if ("1".equals(result)) {
-                                    // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
-                                    Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
-                                    startActivity(intent);
-                                } else {
+                                if (result.equals("null")) {
                                     // 중복된 전화번호 정보가 없는 경우 (처음 가입하는 전화번호의 경우)
                                     Intent intent = new Intent(LoginActivity.this, SignUpActivity.class);
                                     intent.putExtra("phoneNumber", binding.phoneNumberEditText.getText().toString());
                                     startActivity(intent);
+                                    return;
                                 }
+
+                                // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
+                                Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
+                                startActivity(intent);
+                                return;
                             }
                         } catch (IOException e) {
                             e.printStackTrace();

--- a/app/src/main/java/com/project/togather/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/LoginActivity.java
@@ -8,13 +8,29 @@ import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.View;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.project.togather.databinding.ActivityLoginBinding;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
+import java.io.IOException;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
 
 public class LoginActivity extends AppCompatActivity {
 
@@ -25,6 +41,11 @@ public class LoginActivity extends AppCompatActivity {
 
     // 타이머 변수
     private CountDownTimer countDownTimer;
+
+    // Retrofit 객체
+    private UserAPI userAPI;
+    private TokenManager tokenManager;
+    private RetrofitService retrofitService;
 
     // 타이머 시작 메서드
     private void startTimer() {
@@ -52,11 +73,63 @@ public class LoginActivity extends AppCompatActivity {
         }.start();
     }
 
+    // 전화번호 중복 확인 메서드
+    private void checkPhoneNumber(String phoneNumber) {
+        Call<ResponseBody> call = userAPI.checkPhoneNumber(phoneNumber);
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    // API 요청이 성공한 경우
+                    ResponseBody responseBody = response.body();
+                    if (responseBody != null) {
+                        // API 요청으로 받은 데이터가 null이 아닌 경우
+                        Gson gson = new Gson();
+                        try {
+                            String json = responseBody.string();
+                            JsonObject jsonObject = gson.fromJson(json, JsonObject.class);
+
+                            if(jsonObject != null && jsonObject.has("result")) {
+                                String result = jsonObject.get("result").getAsString();
+                                if("1".equals(result)) {
+                                    // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
+                                    Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
+                                    startActivity(intent);
+                                } else {
+                                    // 중복된 전화번호 정보가 없는 경우 (처음 가입하는 전화번호의 경우)
+                                    Intent intent = new Intent(LoginActivity.this, SignUpActivity.class);
+                                    intent.putExtra("phoneNumber", binding.phoneNumberEditText.getText().toString());
+                                    startActivity(intent);
+                                }
+                            }
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        // API 요청으로 받은 데이터가 null인 경우
+                    }
+                }
+                else {
+                    // 요청이 실패한 경우
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                // 네트워크 요청 오류
+            }
+        });
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding = ActivityLoginBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         /** (뒤로가기 화살표 이미지) 버튼 클릭 시 */
         binding.backImageButton.setOnClickListener(new View.OnClickListener() {
@@ -186,9 +259,7 @@ public class LoginActivity extends AppCompatActivity {
                 String systemAuthCodeText = "909409";
 
                 if (usersAuthCodeText.equals(systemAuthCodeText)) {
-                    Intent intent = new Intent(LoginActivity.this, SignUpActivity.class);
-                    intent.putExtra("phoneNumber", binding.phoneNumberEditText.getText().toString());
-                    startActivity(intent);
+                    checkPhoneNumber(binding.phoneNumberEditText.getText().toString());
                     return;
                 }
 

--- a/app/src/main/java/com/project/togather/retrofit/RetrofitService.java
+++ b/app/src/main/java/com/project/togather/retrofit/RetrofitService.java
@@ -1,0 +1,35 @@
+package com.project.togather.retrofit;
+
+import com.google.gson.Gson;
+import com.project.togather.utils.AuthInterceptor;
+import com.project.togather.utils.TokenManager;
+
+import okhttp3.OkHttpClient;
+import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
+
+public class RetrofitService {
+    private Retrofit retrofit;
+    private AuthInterceptor authInterceptor;
+
+    public RetrofitService(TokenManager tokenManager) {
+        authInterceptor = new AuthInterceptor(tokenManager);
+        initializeRetrofit();
+    }
+
+    private void initializeRetrofit() {
+        OkHttpClient client = new OkHttpClient.Builder()
+                .addInterceptor(authInterceptor)
+                .build();
+
+        retrofit = new Retrofit.Builder()
+                .baseUrl("http://10.0.2.2:8080")
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create(new Gson()))
+                .build();
+    }
+
+    public Retrofit getRetrofit() {
+        return retrofit;
+    }
+}

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -1,0 +1,11 @@
+package com.project.togather.retrofit.interfaceAPI;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Query;
+
+public interface UserAPI {
+    @GET("/user/phone")
+    Call<ResponseBody> checkPhoneNumber(@Query("phone") String phoneNumber);
+}

--- a/app/src/main/java/com/project/togather/utils/AuthInterceptor.java
+++ b/app/src/main/java/com/project/togather/utils/AuthInterceptor.java
@@ -1,0 +1,32 @@
+package com.project.togather.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class AuthInterceptor implements Interceptor {
+
+    private TokenManager tokenManager;
+
+    public AuthInterceptor(TokenManager tokenManager) {
+        this.tokenManager = tokenManager;
+    }
+
+    @NotNull
+    @Override
+    public Response intercept(@NotNull Chain chain) throws IOException {
+        Request request = chain.request();
+        Request newRequest;
+
+        String token = tokenManager.getToken();
+        newRequest = request.newBuilder()
+                .addHeader("Authorization", "Bearer " + token)
+                .build();
+
+        return chain.proceed(newRequest);
+    }
+}

--- a/app/src/main/java/com/project/togather/utils/TokenManager.java
+++ b/app/src/main/java/com/project/togather/utils/TokenManager.java
@@ -1,0 +1,79 @@
+package com.project.togather.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.json.JSONObject;
+
+public class TokenManager {
+    private final SharedPreferences prefs;
+    private static TokenManager INSTANCE = null;
+
+    private TokenManager(Context context) {
+        prefs = context.getSharedPreferences("JWT_TOKEN_PREFS", Context.MODE_PRIVATE);
+    }
+
+    public static synchronized TokenManager getInstance(Context context) {
+        if (INSTANCE == null) {
+            INSTANCE = new TokenManager(context);
+        }
+        return INSTANCE;
+    }
+
+    public void saveToken(String token) {
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString("JWT_TOKEN", token);
+        editor.apply();
+    }
+
+    public String getToken() {
+        return prefs.getString("JWT_TOKEN", null);
+    }
+
+    public void saveUserInfo(JSONObject jsonObject) {
+        String userId = jsonObject.optString("_id");
+        String email = jsonObject.optString("email");
+        String username = jsonObject.optString("username");
+        String role = jsonObject.optString("role");
+        int point = jsonObject.optInt("point");
+
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.putString("userId`", userId);
+        editor.putString("email", email);
+        editor.putString("username", username);
+        editor.putString("role", role);
+        editor.putInt("point", point);
+        editor.apply();
+    }
+
+    public void logout() {
+        SharedPreferences.Editor editor = prefs.edit();
+        // 토큰 제거
+        editor.remove("JWT_TOKEN");
+        // 사용자 정보 제거
+        editor.remove("userId");
+        editor.remove("email");
+        editor.remove("username");
+        editor.remove("role");
+        editor.remove("point");
+        editor.apply();
+    }
+
+    public String getUserId() {
+        return prefs.getString("userId", null);
+    }
+
+    public String getEmail() {
+        return prefs.getString("email", null);
+    }
+
+    public String getUsername() {
+        return prefs.getString("username", null);
+    }
+
+    public String getRole() {
+        return prefs.getString("role", null);
+    }
+
+    public int getPoint() { return prefs.getInt("point", 0); }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
 
     <!-- Strings related to (Toast) -->
     <string name="toast_can_auth_code_confirm_daily_limit_warning">일일 문자 인증 가능 건수</string>
+    <string name="toast_server_error">서버 에러가 발생했어요</string>
 
     <!-- Strings related to (LoginActivity) -->
     <string name="auth_code_warning">어떤 경우에도 타인에게 공유하지 마세요!</string>


### PR DESCRIPTION
## 👀 이슈

resolve #6 

## 📌 개요

중복된 전화번호로 로그인 시 회원가입 없이 홈 액티비티로 이동하는 기능을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- retrofit 라이브러리 추가
- retrofit 라이브러리 사용하여 API 요청 위해 초기 설정
- 전화번호 중복 여부에 따라 중복된 전화번호 (이미 가입된 번호)의 경우 홈 액티비티로 이동 
그렇지 않다면 회원가입 액티비티로 이동 

## ✅ 참고 사항

- 기능 추가 후 `로그인` 화면

[Screen_recording_20240413_161215.webm](https://github.com/cbnu-togather/togather-client/assets/127587330/df52012f-522c-42d5-84b0-db0dc9381c0f)
