### PR TITLE
[feat]: 로그인 및 회원가입 기능 추가

### DIFF
--- a/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
@@ -357,6 +357,7 @@ public class CreateCommunityPostActivity extends AppCompatActivity {
             }
 
             startActivity(new Intent(CreateCommunityPostActivity.this, CommunityPostDetailActivity.class));
+            finish();
         });
 
         /** (제목) 입력란 텍스트 입력 시 */

--- a/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
@@ -369,6 +369,7 @@ public class CreateRecruitmentPostActivity extends AppCompatActivity {
             }
 
             startActivity(new Intent(CreateRecruitmentPostActivity.this, RecruitmentPostDetailActivity.class));
+            finish();
         });
     }
 

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -15,4 +15,6 @@ public interface UserAPI {
             @Query("phone") String phone,
             @Query("name") String name
     );
+    @POST("/login")
+    Call<ResponseBody> login(@Query("phone") String phone);
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -9,7 +9,8 @@ import retrofit2.http.Query;
 public interface UserAPI {
     @GET("/user/phone")
     Call<ResponseBody> checkPhoneNumber(@Query("phone") String phone);
-
+    @GET("/user/doublecheck")
+    Call<Boolean> doubleCheckUserName(@Query("name") String name);
     @POST("/user")
     Call<ResponseBody> signUp(
             @Query("phone") String phone,
@@ -17,4 +18,5 @@ public interface UserAPI {
     );
     @POST("/login")
     Call<ResponseBody> login(@Query("phone") String phone);
+
 }

--- a/app/src/main/java/com/project/togather/user/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/user/LoginActivity.java
@@ -75,7 +75,7 @@ public class LoginActivity extends AppCompatActivity {
     }
 
     // 로그인 메서드
-    private void login(String phoneNumber) {
+    private void performLogin(String phoneNumber) {
         Call<ResponseBody> call = userAPI.login(phoneNumber);
         call.enqueue(new Callback<ResponseBody>() {
             @Override
@@ -146,7 +146,7 @@ public class LoginActivity extends AppCompatActivity {
                                     return;
                                 }
                                 // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
-                                login(finalPhoneNumber);
+                                performLogin(finalPhoneNumber);
                                 return;
                             }
                         } catch (IOException e) {

--- a/app/src/main/java/com/project/togather/user/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/user/LoginActivity.java
@@ -21,6 +21,9 @@ import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -71,11 +74,55 @@ public class LoginActivity extends AppCompatActivity {
         }.start();
     }
 
+    // 로그인 메서드
+    private void login(String phoneNumber) {
+        Call<ResponseBody> call = userAPI.login(phoneNumber);
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    // 로그인 성공 시
+                    ResponseBody responseBody = response.body();
+                    if (responseBody != null) {
+                        // API 요청으로 받은 데이터가 null이 아닌 경우
+                        try {
+                            String json = responseBody.string();
+                            JSONObject jsonObject = new JSONObject(json);
+
+                            String token = jsonObject.getString("token");
+                            tokenManager.saveToken(token);
+
+                            Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
+                            startActivity(intent);
+                        } catch (IOException | JSONException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    else {
+                        // API 요청으로 받은 데이터가 null인 경우
+
+                        return ;
+                    }
+                }
+                else {
+                    // 요청이 실패한 경우
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                // 서버 코드 및 네트워크 오류 등의 이유로 요청 실패
+                new ToastWarning(getResources().getString(R.string.toast_server_error), LoginActivity.this);
+            }
+        });
+    }
+
     // 전화번호 중복 확인 메서드
     private void checkPhoneNumber(String phoneNumber) {
         // 전화번호 문자열 내 공백을 제거
-        phoneNumber = phoneNumber.replaceAll("\\s", "");
-        Call<ResponseBody> call = userAPI.checkPhoneNumber(phoneNumber);
+        String finalPhoneNumber = phoneNumber.replaceAll("\\s", "");
+        Call<ResponseBody> call = userAPI.checkPhoneNumber(finalPhoneNumber);
+
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
@@ -98,10 +145,8 @@ public class LoginActivity extends AppCompatActivity {
                                     startActivity(intent);
                                     return;
                                 }
-
                                 // 중복된 전화번호 정보가 있는 경우(이미 가입된 전화번호의 경우)
-                                Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
-                                startActivity(intent);
+                                login(finalPhoneNumber);
                                 return;
                             }
                         } catch (IOException e) {

--- a/app/src/main/java/com/project/togather/user/SignUpActivity.java
+++ b/app/src/main/java/com/project/togather/user/SignUpActivity.java
@@ -200,7 +200,7 @@ public class SignUpActivity extends AppCompatActivity {
                     Boolean isUserNameAvailable = response.body();
                     // 중복된 유저 이름으로 가입 시도시
                     if (isUserNameAvailable != null && isUserNameAvailable) {
-                        new ToastWarning("이미 존재하는 유저 이름입니다.", SignUpActivity.this);
+                        new ToastWarning("이미 사용 중인 이름이에요", SignUpActivity.this);
                         return;
                     }
 
@@ -211,7 +211,7 @@ public class SignUpActivity extends AppCompatActivity {
                         public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
                             if (response.isSuccessful()) {
                                 // 회원가입 성공 후 로그인 시도
-                                new ToastSuccess("회원가입 완료", SignUpActivity.this);
+                                new ToastSuccess("가입이 완료되었어요", SignUpActivity.this);
                                 performLogin(phoneNumber);
                                 return ;
                             }

--- a/app/src/main/java/com/project/togather/utils/TokenManager.java
+++ b/app/src/main/java/com/project/togather/utils/TokenManager.java
@@ -51,11 +51,11 @@ public class TokenManager {
         // 토큰 제거
         editor.remove("JWT_TOKEN");
         // 사용자 정보 제거
-        editor.remove("userId");
-        editor.remove("email");
-        editor.remove("username");
-        editor.remove("role");
-        editor.remove("point");
+//        editor.remove("userId");
+//        editor.remove("email");
+//        editor.remove("username");
+//        editor.remove("role");
+//        editor.remove("point");
         editor.apply();
     }
 


### PR DESCRIPTION
## 👀 이슈

resolve #24 

## 📌 개요

로그인 후 jwt 토큰 값을 전역으로 저장하고 회원가입 과정에서 닉네임 중복확인 기능을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- `로그인` 액티비티에서 전화번호 인증 후 로그인 요청보내는 기능 추가
- SharedPreference 라이브러리를 활용하여 로그인 성공 시 발급되는 토큰 값을 전역으로 관리하는 기능 추가
- `회원가입` 액티비티에서 이미 가입된 중복되 닉네임으로 가입이 불가능하게 중복 확인하는 기능 추가 
- `모집 글 작성`, `동네생활 글 작성` 액티비티에서 글 작성 후 뒤로가기 시 다시 작성 액티비티로 이동하는 문제 수정

## ✅ 참고 사항

- 회원 가입 기능 추가 영상
[Screen_recording_20240511_143927.webm](https://github.com/cbnu-togather/togather-client/assets/127587330/9263cf02-dcb8-4979-975b-41e2a632a9b3)

- 닉네임 중복확인 기능 추가 영상
[Screen_recording_20240511_144007.webm](https://github.com/cbnu-togather/togather-client/assets/127587330/767b8d35-3674-4503-8809-40ed96639ee3)
