### PR TITLE
[feat]: 회원 로그아웃/탈퇴 및 회원 정보 조회/수정 기능 추가

### DIFF
--- a/app/src/main/java/com/project/togather/MainActivity.java
+++ b/app/src/main/java/com/project/togather/MainActivity.java
@@ -21,10 +21,12 @@ import com.project.togather.databinding.ActivityMainBinding;
 import com.project.togather.editPost.recruitment.EditRecruitmentPostActivity;
 import com.project.togather.home.HomeActivity;
 import com.project.togather.user.LoginActivity;
+import com.project.togather.utils.TokenManager;
 
 public class MainActivity extends AppCompatActivity {
 
     private ActivityMainBinding binding;
+    private TokenManager tokenManager;
 
     /**
      * 위치 권한 요청 코드의 상숫값
@@ -38,13 +40,20 @@ public class MainActivity extends AppCompatActivity {
         binding = ActivityMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        tokenManager = TokenManager.getInstance(this);
+
         /** (시작하기) 버튼 클릭 시 */
         binding.startButton.setOnClickListener(view -> {
             if (ActivityCompat.checkSelfPermission(this, android.Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
                 requestPermissions();
                 return;
             }
-
+            // 현재 유효한 토큰 값이 존재할 경우 시작하기 버튼 클릭 시 홈 액티비티로 이동
+            if (tokenManager.getToken() != null) {
+                startActivity(new Intent(MainActivity.this, HomeActivity.class));
+                finish();
+                return ;
+            }
             startActivity(new Intent(MainActivity.this, LoginActivity.class));
         });
 

--- a/app/src/main/java/com/project/togather/chat/ChatActivity.java
+++ b/app/src/main/java/com/project/togather/chat/ChatActivity.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.R;
 import com.project.togather.createPost.recruitment.CreateRecruitmentPostActivity;
@@ -35,13 +36,14 @@ import java.util.Date;
 import java.util.Locale;
 
 import com.project.togather.databinding.ActivityChatBinding;
+import com.project.togather.utils.TokenManager;
 
 public class ChatActivity extends AppCompatActivity {
 
     private ActivityChatBinding binding;
 
     private RecyclerViewAdapter adapter;
-
+    private TokenManager tokenManager;
     private final OnBackPressedDispatcher onBackPressedDispatcher = getOnBackPressedDispatcher();
 
     private BottomSheetBehavior selectCreatePostTypeBottomSheetBehavior;
@@ -51,6 +53,14 @@ public class ChatActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityChatBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(ChatActivity.this, MainActivity.class));
+            finish();
+        }
 
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {
             @Override

--- a/app/src/main/java/com/project/togather/chat/ChatDetailActivity.java
+++ b/app/src/main/java/com/project/togather/chat/ChatDetailActivity.java
@@ -35,8 +35,10 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import android.Manifest;
 
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityChatDetailBinding;
+import com.project.togather.utils.TokenManager;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.cardview.widget.CardView;
@@ -58,6 +60,7 @@ public class ChatDetailActivity extends AppCompatActivity {
     private final OnBackPressedDispatcher onBackPressedDispatcher = getOnBackPressedDispatcher();
 
     private RecyclerViewAdapter adapter;
+    private TokenManager tokenManager;
 
     private BottomSheetBehavior moreMenuBottomSheetBehavior;
     private BottomSheetBehavior addMenuBottomSheetBehavior;
@@ -74,6 +77,14 @@ public class ChatDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityChatDetailBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(ChatDetailActivity.this, MainActivity.class));
+            finish();
+        }
 
         /** (로그아웃 확인) 다이얼로그 변수 초기화 및 설정 */
         askLeaveChatRoom_dialog = new Dialog(ChatDetailActivity.this);  // Dialog 초기화

--- a/app/src/main/java/com/project/togather/community/CommunityActivity.java
+++ b/app/src/main/java/com/project/togather/community/CommunityActivity.java
@@ -23,6 +23,7 @@ import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.chat.ChatActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.createPost.recruitment.CreateRecruitmentPostActivity;
@@ -31,6 +32,7 @@ import com.project.togather.notification.NotificationActivity;
 import com.project.togather.profile.ProfileActivity;
 import com.project.togather.R;
 import com.project.togather.home.HomeActivity;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
@@ -39,6 +41,7 @@ public class CommunityActivity extends AppCompatActivity {
     private ActivityCommunityBinding binding;
 
     private RecyclerViewAdapter adapter;
+    private TokenManager tokenManager;
 
     ArrayList<PostInfoItem> postInfoItems = new ArrayList<>();
 
@@ -51,6 +54,14 @@ public class CommunityActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityCommunityBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(CommunityActivity.this, MainActivity.class));
+            finish();
+        }
 
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {
             @Override

--- a/app/src/main/java/com/project/togather/community/CommunityPostDetailActivity.java
+++ b/app/src/main/java/com/project/togather/community/CommunityPostDetailActivity.java
@@ -31,11 +31,13 @@ import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityCommunityPostDetailBinding;
 import com.project.togather.editPost.community.EditCommunityPostActivity;
 import com.project.togather.editPost.community.EditCommunityPostCommentActivity;
 import com.project.togather.editPost.recruitment.EditRecruitmentPostActivity;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -45,6 +47,7 @@ public class CommunityPostDetailActivity extends AppCompatActivity {
     private static ActivityCommunityPostDetailBinding binding;
 
     private static RecyclerViewAdapter adapter;
+    private TokenManager tokenManager;
 
     private BottomSheetBehavior selectPostManagementBottomSheetBehavior;
     private static BottomSheetBehavior selectCommentManagementBottomSheetBehavior;
@@ -63,6 +66,14 @@ public class CommunityPostDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityCommunityPostDetailBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(CommunityPostDetailActivity.this, MainActivity.class));
+            finish();
+        }
 
         selectedImageUri = Uri.parse("");
 

--- a/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
@@ -27,12 +27,14 @@ import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.databinding.ActivityCreateCommunityPostBinding;
 import com.project.togather.toast.ToastSuccess;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
 public class CreateCommunityPostActivity extends AppCompatActivity {
 
     private ActivityCreateCommunityPostBinding binding;
+    private TokenManager tokenManager;
 
     private BottomSheetBehavior selectCategoryBottomSheetBehavior;
 
@@ -45,6 +47,14 @@ public class CreateCommunityPostActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityCreateCommunityPostBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(CreateCommunityPostActivity.this, MainActivity.class));
+            finish();
+        }
 
         selectedImageUri = Uri.parse("");
 

--- a/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
@@ -21,18 +21,21 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivityCreateRecruitmentPostBinding;
 import com.project.togather.home.RecruitmentPostDetailActivity;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
 public class CreateRecruitmentPostActivity extends AppCompatActivity {
 
     private ActivityCreateRecruitmentPostBinding binding;
+    private TokenManager tokenManager;
 
     private BottomSheetBehavior selectFoodCategoryBottomSheetBehavior;
 
@@ -49,6 +52,14 @@ public class CreateRecruitmentPostActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityCreateRecruitmentPostBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(CreateRecruitmentPostActivity.this, MainActivity.class));
+            finish();
+        }
 
         selectedImageUri = Uri.parse("");
 

--- a/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
@@ -40,6 +40,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.project.togather.GetMyLocation;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivitySelectMeetingSpotBinding;
@@ -48,6 +49,7 @@ import com.project.togather.model.CoordinateToAddress;
 import com.project.togather.retrofit.RetrofitServiceForKakao;
 import com.project.togather.retrofit.interfaceAPI.KakaoAPI;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import net.daum.mf.map.api.MapView;
 import net.daum.mf.map.api.MapPOIItem;
@@ -62,6 +64,7 @@ import retrofit2.Response;
 public class SelectMeetingSpotActivity extends AppCompatActivity implements net.daum.mf.map.api.MapView.CurrentLocationEventListener, net.daum.mf.map.api.MapView.MapViewEventListener, net.daum.mf.map.api.MapView.POIItemEventListener {
 
     private ActivitySelectMeetingSpotBinding binding;
+    private TokenManager tokenManager;
 
     /**
      * 위치 권한 요청 코드의 상숫값
@@ -117,6 +120,14 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
         super.onCreate(savedInstanceState);
         binding = ActivitySelectMeetingSpotBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(SelectMeetingSpotActivity.this, MainActivity.class));
+            finish();
+        }
 
         // 전역 데이터 로드
         SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE);

--- a/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostActivity.java
@@ -24,19 +24,21 @@ import androidx.core.view.WindowInsetsCompat;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivityCommunityPostDetailBinding;
 import com.project.togather.databinding.ActivityEditCommunityPostBinding;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
 public class EditCommunityPostActivity extends AppCompatActivity {
 
     private ActivityEditCommunityPostBinding binding;
-
+    private TokenManager tokenManager;
     private BottomSheetBehavior selectCategoryBottomSheetBehavior;
 
     private static final int REQUEST_GALLERY = 2;
@@ -48,6 +50,14 @@ public class EditCommunityPostActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityEditCommunityPostBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(EditCommunityPostActivity.this, MainActivity.class));
+            finish();
+        }
 
         // X 이미지뷰 클릭 시 현재 액티비티 종료
         binding.closeActivityImageView.setOnClickListener(view -> finish());

--- a/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostCommentActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostCommentActivity.java
@@ -20,15 +20,18 @@ import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityEditCommunityPostCommentBinding;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
 public class EditCommunityPostCommentActivity extends AppCompatActivity {
 
     private ActivityEditCommunityPostCommentBinding binding;
+    private TokenManager tokenManager;
 
     private static Dialog askCancelWriteComment_dialog;
 
@@ -41,6 +44,14 @@ public class EditCommunityPostCommentActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityEditCommunityPostCommentBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(EditCommunityPostCommentActivity.this, MainActivity.class));
+            finish();
+        }
 
         selectedImageUri = Uri.parse("");
 

--- a/app/src/main/java/com/project/togather/editPost/recruitment/EditRecruitmentPostActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/recruitment/EditRecruitmentPostActivity.java
@@ -23,16 +23,19 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityEditRecruitmentPostBinding;
 import com.project.togather.home.RecruitmentPostDetailActivity;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
 public class EditRecruitmentPostActivity extends AppCompatActivity {
 
     private ActivityEditRecruitmentPostBinding binding;
+    private TokenManager tokenManager;
 
     private BottomSheetBehavior selectFoodCategoryBottomSheetBehavior;
 
@@ -49,6 +52,14 @@ public class EditRecruitmentPostActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityEditRecruitmentPostBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(EditRecruitmentPostActivity.this, MainActivity.class));
+            finish();
+        }
 
         // 전역 데이터 초기화
         SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE);

--- a/app/src/main/java/com/project/togather/editPost/recruitment/EditRecruitmentPostSelectMeetingSpotActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/recruitment/EditRecruitmentPostSelectMeetingSpotActivity.java
@@ -38,12 +38,14 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.project.togather.GetMyLocation;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivitySelectMeetingSpotBinding;
 import com.project.togather.model.CoordinateToAddress;
 import com.project.togather.retrofit.RetrofitServiceForKakao;
 import com.project.togather.retrofit.interfaceAPI.KakaoAPI;
 import com.project.togather.toast.ToastWarning;
+import com.project.togather.utils.TokenManager;
 
 import net.daum.mf.map.api.MapPOIItem;
 import net.daum.mf.map.api.MapPoint;
@@ -58,6 +60,7 @@ import retrofit2.Response;
 public class EditRecruitmentPostSelectMeetingSpotActivity extends AppCompatActivity implements MapView.CurrentLocationEventListener, MapView.MapViewEventListener, MapView.POIItemEventListener {
 
     private ActivitySelectMeetingSpotBinding binding;
+    private TokenManager tokenManager;
 
     /**
      * 위치 권한 요청 코드의 상숫값
@@ -113,6 +116,14 @@ public class EditRecruitmentPostSelectMeetingSpotActivity extends AppCompatActiv
         super.onCreate(savedInstanceState);
         binding = ActivitySelectMeetingSpotBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(EditRecruitmentPostSelectMeetingSpotActivity.this, MainActivity.class));
+            finish();
+        }
 
         // 전역 데이터 로드
         SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE);

--- a/app/src/main/java/com/project/togather/home/HomeActivity.java
+++ b/app/src/main/java/com/project/togather/home/HomeActivity.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
+import com.project.togather.MainActivity;
 import com.project.togather.chat.ChatActivity;
 import com.project.togather.community.CommunityActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
@@ -32,6 +33,7 @@ import com.project.togather.databinding.ActivityHomeBinding;
 import com.project.togather.notification.NotificationActivity;
 import com.project.togather.profile.ProfileActivity;
 import com.project.togather.R;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
@@ -40,6 +42,7 @@ public class HomeActivity extends AppCompatActivity {
     private ActivityHomeBinding binding;
 
     private RecyclerViewAdapter adapter;
+    private TokenManager tokenManager;
 
     private ArrayList<PostInfoItem> postInfoItems = new ArrayList<>();
 
@@ -53,6 +56,14 @@ public class HomeActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityHomeBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(HomeActivity.this, MainActivity.class));
+            finish();
+        }
 
         // Add callback listener
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {

--- a/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
+++ b/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
@@ -26,6 +26,7 @@ import com.project.togather.databinding.ActivityRecruitmentPostDetailBinding;
 import com.project.togather.editPost.recruitment.EditRecruitmentPostActivity;
 import com.project.togather.toast.ToastSuccess;
 import com.project.togather.user.LoginActivity;
+import com.project.togather.utils.TokenManager;
 
 import net.daum.mf.map.api.MapPOIItem;
 import net.daum.mf.map.api.MapPoint;
@@ -36,7 +37,7 @@ public class RecruitmentPostDetailActivity extends AppCompatActivity {
     private ActivityRecruitmentPostDetailBinding binding;
 
     private BottomSheetBehavior selectPostManagementBottomSheetBehavior;
-
+    private TokenManager tokenManager;
     private Dialog askDeletePost_dialog, askJoinParty_dialog, askStopRecruitment_dialog;
 
     private boolean isWriter, isLiked, isRecruitmentComplete;
@@ -57,6 +58,14 @@ public class RecruitmentPostDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityRecruitmentPostDetailBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(RecruitmentPostDetailActivity.this, MainActivity.class));
+            finish();
+        }
 
         binding.activityHeaderRelativeLayout.bringToFront();
 

--- a/app/src/main/java/com/project/togather/home/SelectedSpotActivity.java
+++ b/app/src/main/java/com/project/togather/home/SelectedSpotActivity.java
@@ -2,6 +2,7 @@ package com.project.togather.home;
 
 import android.app.Dialog;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.location.Location;
@@ -17,9 +18,11 @@ import androidx.activity.OnBackPressedDispatcher;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.project.togather.GetMyLocation;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivitySelectedSpotBinding;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.utils.TokenManager;
 
 import net.daum.mf.map.api.MapPOIItem;
 import net.daum.mf.map.api.MapPoint;
@@ -28,6 +31,7 @@ import net.daum.mf.map.api.MapView;
 public class SelectedSpotActivity extends AppCompatActivity implements net.daum.mf.map.api.MapView.CurrentLocationEventListener, net.daum.mf.map.api.MapView.MapViewEventListener, net.daum.mf.map.api.MapView.POIItemEventListener {
 
     private ActivitySelectedSpotBinding binding;
+    private TokenManager tokenManager;
 
     private Dialog askJoinParty_dialog;
 
@@ -49,6 +53,14 @@ public class SelectedSpotActivity extends AppCompatActivity implements net.daum.
         super.onCreate(savedInstanceState);
         binding = ActivitySelectedSpotBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(SelectedSpotActivity.this, MainActivity.class));
+            finish();
+        }
 
         /** (손 들기 확인) 다이얼로그 변수 초기화 및 설정 */
         askJoinParty_dialog = new Dialog(SelectedSpotActivity.this);  // Dialog 초기화

--- a/app/src/main/java/com/project/togather/notification/NotificationActivity.java
+++ b/app/src/main/java/com/project/togather/notification/NotificationActivity.java
@@ -29,16 +29,19 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.chat.ChatDetailActivity;
 import com.project.togather.databinding.ActivityNotificationBinding;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
 public class NotificationActivity extends AppCompatActivity {
 
     private ActivityNotificationBinding binding;
+    private TokenManager tokenManager;
 
     private RecyclerViewAdapter adapter;
 
@@ -49,6 +52,14 @@ public class NotificationActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityNotificationBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(NotificationActivity.this, MainActivity.class));
+            finish();
+        }
 
         // 알림 권한 요청
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/java/com/project/togather/profile/EditMyProfile.java
+++ b/app/src/main/java/com/project/togather/profile/EditMyProfile.java
@@ -163,7 +163,7 @@ public class EditMyProfile extends AppCompatActivity {
                     @Override
                     public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
                         if (response.isSuccessful()) {
-                            new ToastSuccess("회원정보 수정 완료", EditMyProfile.this);
+                            new ToastSuccess("정보가 수정되었어요", EditMyProfile.this);
                             if (tokenManager.getToken() != null) {
                                 getUserInfo();
                             }

--- a/app/src/main/java/com/project/togather/profile/EditMyProfile.java
+++ b/app/src/main/java/com/project/togather/profile/EditMyProfile.java
@@ -24,9 +24,11 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityEditMyProfileBinding;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
@@ -35,6 +37,9 @@ public class EditMyProfile extends AppCompatActivity {
     private ActivityEditMyProfileBinding binding;
 
     private Bitmap bitmap;
+    private UserAPI userAPI;
+    private TokenManager tokenManager;
+    private RetrofitService retrofitService;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -42,6 +47,15 @@ public class EditMyProfile extends AppCompatActivity {
         binding = ActivityEditMyProfileBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
+        tokenManager = TokenManager.getInstance(this);
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(EditMyProfile.this, MainActivity.class));
+            finish();
+        }
         setupListeners();
     }
 

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -36,6 +36,12 @@ import com.project.togather.profile.myRecruitmentPartyPost.MyRecruitmentPartyPos
 import com.project.togather.user.SignUpActivity;
 import com.project.togather.utils.TokenManager;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -247,6 +253,43 @@ public class ProfileActivity extends AppCompatActivity {
         });
     }
 
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    try {
+                        String responseBodyString = response.body().string();
+                        JSONObject jsonObject = new JSONObject(responseBodyString);
+
+                        String userName = jsonObject.getString("name");
+                        String photo = jsonObject.getString("photo");
+
+                        // 내 유저 이름을 표시
+                        binding.userNameTextView.setText(userName);
+
+                        // 내 프로필 사진을 표시
+                        Glide.with(ProfileActivity.this)
+                                .load(photo)
+                                .placeholder(R.drawable.one_person_logo)
+                                .error(R.drawable.one_person_logo)
+                                .into(binding.userProfileImageRoundedImageView);
+
+                    } catch (IOException | JSONException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), ProfileActivity.this);
+            }
+        });
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
@@ -256,15 +299,7 @@ public class ProfileActivity extends AppCompatActivity {
             startActivity(new Intent(ProfileActivity.this, MainActivity.class));
             finish();
         }
+        getUserInfo();
 
-        // 내 유저 이름을 표시
-        binding.userNameTextView.setText(tokenManager.getUsername());
-
-        // 내 프로필 사진을 표시
-        Glide.with(this)
-                .load(tokenManager.getPhoto())
-                .placeholder(R.drawable.one_person_logo)
-                .error(R.drawable.one_person_logo)
-                .into(binding.userProfileImageRoundedImageView);
     }
 }

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -64,26 +64,6 @@ public class ProfileActivity extends AppCompatActivity {
         retrofitService = new RetrofitService(tokenManager);
         userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(ProfileActivity.this, MainActivity.class));
-            finish();
-        }
-
-        // 액티비티 생성 시 내 유저 이름을 표시
-        if (tokenManager.getUsername() != null) {
-            binding.userNameTextView.setText(tokenManager.getUsername());
-        }
-
-        // 액티비티 생성 시 내 프로필 사진을 표시
-        if (tokenManager.getPhoto() != null) {
-            Glide.with(this)
-                    .load(tokenManager.getPhoto())
-                    .placeholder(R.drawable.one_person_logo)
-                    .error(R.drawable.one_person_logo)
-                    .into(binding.userProfileImageRoundedImageView);
-        }
-
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
@@ -265,5 +245,26 @@ public class ProfileActivity extends AppCompatActivity {
                 new ToastWarning(getResources().getString(R.string.toast_server_error), ProfileActivity.this);
             }
         });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(ProfileActivity.this, MainActivity.class));
+            finish();
+        }
+
+        // 내 유저 이름을 표시
+        binding.userNameTextView.setText(tokenManager.getUsername());
+
+        // 내 프로필 사진을 표시
+        Glide.with(this)
+                .load(tokenManager.getPhoto())
+                .placeholder(R.drawable.one_person_logo)
+                .error(R.drawable.one_person_logo)
+                .into(binding.userProfileImageRoundedImageView);
     }
 }

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.Window;
 import android.widget.Button;
 
+import com.bumptech.glide.Glide;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.project.togather.MainActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
@@ -68,6 +69,21 @@ public class ProfileActivity extends AppCompatActivity {
             startActivity(new Intent(ProfileActivity.this, MainActivity.class));
             finish();
         }
+
+        // 액티비티 생성 시 내 유저 이름을 표시
+        if (tokenManager.getUsername() != null) {
+            binding.userNameTextView.setText(tokenManager.getUsername());
+        }
+
+        // 액티비티 생성 시 내 프로필 사진을 표시
+        if (tokenManager.getPhoto() != null) {
+            Glide.with(this)
+                    .load(tokenManager.getPhoto())
+                    .placeholder(R.drawable.one_person_logo)
+                    .error(R.drawable.one_person_logo)
+                    .into(binding.userProfileImageRoundedImageView);
+        }
+
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -63,6 +63,11 @@ public class ProfileActivity extends AppCompatActivity {
         retrofitService = new RetrofitService(tokenManager);
         userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(ProfileActivity.this, MainActivity.class));
+            finish();
+        }
         onBackPressedDispatcher.addCallback(new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {

--- a/app/src/main/java/com/project/togather/profile/likedPost/LikedPostListActivity.java
+++ b/app/src/main/java/com/project/togather/profile/likedPost/LikedPostListActivity.java
@@ -19,15 +19,18 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityLikedPostListBinding;
 import com.project.togather.home.RecruitmentPostDetailActivity;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
 public class LikedPostListActivity extends AppCompatActivity {
 
     private ActivityLikedPostListBinding binding;
+    private TokenManager tokenManager;
 
     private RecyclerViewAdapter adapter;
 
@@ -36,6 +39,14 @@ public class LikedPostListActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityLikedPostListBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(LikedPostListActivity.this, MainActivity.class));
+            finish();
+        }
 
         adapter = new RecyclerViewAdapter();
 

--- a/app/src/main/java/com/project/togather/profile/myCommunityPost/MyCommunityPostListActivity.java
+++ b/app/src/main/java/com/project/togather/profile/myCommunityPost/MyCommunityPostListActivity.java
@@ -19,15 +19,18 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.databinding.ActivityMyCommunityPostListBinding;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
 public class MyCommunityPostListActivity extends AppCompatActivity {
 
     private ActivityMyCommunityPostListBinding binding;
+    private TokenManager tokenManager;
 
     private RecyclerViewAdapter adapter;
 
@@ -36,6 +39,14 @@ public class MyCommunityPostListActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityMyCommunityPostListBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(MyCommunityPostListActivity.this, MainActivity.class));
+            finish();
+        }
 
         adapter = new RecyclerViewAdapter();
 

--- a/app/src/main/java/com/project/togather/profile/myRecruitmentPartyPost/MyRecruitmentPartyPostListActivity.java
+++ b/app/src/main/java/com/project/togather/profile/myRecruitmentPartyPost/MyRecruitmentPartyPostListActivity.java
@@ -19,15 +19,18 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.bumptech.glide.Glide;
+import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityMyRecruitmentPartyListBinding;
 import com.project.togather.home.RecruitmentPostDetailActivity;
+import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
 
 public class MyRecruitmentPartyPostListActivity extends AppCompatActivity {
 
     private ActivityMyRecruitmentPartyListBinding binding;
+    private TokenManager tokenManager;
 
     private RecyclerViewAdapter adapter;
 
@@ -36,6 +39,14 @@ public class MyRecruitmentPartyPostListActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivityMyRecruitmentPartyListBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        tokenManager = TokenManager.getInstance(this);
+
+        // 토큰 값이 없다면 메인 액티비티로 이동
+        if (tokenManager.getToken() == null) {
+            startActivity(new Intent(MyRecruitmentPartyPostListActivity.this, MainActivity.class));
+            finish();
+        }
 
         adapter = new RecyclerViewAdapter();
 

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -2,7 +2,10 @@ package com.project.togather.retrofit.interfaceAPI;
 
 import okhttp3.ResponseBody;
 import retrofit2.Call;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
+import retrofit2.http.Header;
+import retrofit2.http.Headers;
 import retrofit2.http.POST;
 import retrofit2.http.Query;
 
@@ -18,5 +21,8 @@ public interface UserAPI {
     );
     @POST("/login")
     Call<ResponseBody> login(@Query("phone") String phone);
+    @DELETE("/user")
+    @Headers("accept: application/json")
+    Call<Void> deleteUser();
 
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -24,5 +24,8 @@ public interface UserAPI {
     @DELETE("/user")
     @Headers("accept: application/json")
     Call<Void> deleteUser();
+    @GET("/user")
+    @Headers("accept: application/json")
+    Call<ResponseBody> getUserInfo();
 
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -1,12 +1,17 @@
 package com.project.togather.retrofit.interfaceAPI;
 
+import androidx.annotation.Nullable;
+
+import okhttp3.MultipartBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Header;
 import retrofit2.http.Headers;
+import retrofit2.http.Multipart;
 import retrofit2.http.POST;
+import retrofit2.http.Part;
 import retrofit2.http.Query;
 
 public interface UserAPI {
@@ -27,5 +32,11 @@ public interface UserAPI {
     @GET("/user")
     @Headers("accept: application/json")
     Call<ResponseBody> getUserInfo();
+    @Multipart
+    @POST("/user/update")
+    Call<ResponseBody> updateUserProfile(
+            @Query("name") String name,
+            @Part @Nullable MultipartBody.Part img
+            );
 
 }

--- a/app/src/main/java/com/project/togather/user/LoginActivity.java
+++ b/app/src/main/java/com/project/togather/user/LoginActivity.java
@@ -74,6 +74,31 @@ public class LoginActivity extends AppCompatActivity {
         }.start();
     }
 
+
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    try {
+                        String responseBodyString = response.body().string();
+                        JSONObject jsonObject = new JSONObject(responseBodyString);
+
+                        tokenManager.saveUserInfo(jsonObject);
+                    } catch (IOException | JSONException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+
+            }
+        });
+    }
+
     // 로그인 메서드
     private void performLogin(String phoneNumber) {
         Call<ResponseBody> call = userAPI.login(phoneNumber);
@@ -91,6 +116,11 @@ public class LoginActivity extends AppCompatActivity {
 
                             String token = jsonObject.getString("token");
                             tokenManager.saveToken(token);
+
+                            if (tokenManager.getToken() != null) {
+                                getUserInfo();
+                            }
+
 
                             Intent intent = new Intent(LoginActivity.this, HomeActivity.class);
                             startActivity(intent);

--- a/app/src/main/java/com/project/togather/user/SignUpActivity.java
+++ b/app/src/main/java/com/project/togather/user/SignUpActivity.java
@@ -145,6 +145,30 @@ public class SignUpActivity extends AppCompatActivity {
         binding.signUpButton.setOnClickListener(view -> performSignUp());
     }
 
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful()) {
+                    try {
+                        String responseBodyString = response.body().string();
+                        JSONObject jsonObject = new JSONObject(responseBodyString);
+
+                        tokenManager.saveUserInfo(jsonObject);
+                    } catch (IOException | JSONException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+
+            }
+        });
+    }
+
     // 로그인 메서드
     private void performLogin(String phoneNumber) {
         Call<ResponseBody> call = userAPI.login(phoneNumber);
@@ -162,6 +186,10 @@ public class SignUpActivity extends AppCompatActivity {
 
                             String token = jsonObject.getString("token");
                             tokenManager.saveToken(token);
+
+                            if (tokenManager.getToken() != null) {
+                                getUserInfo();
+                            }
 
                             Intent intent = new Intent(SignUpActivity.this, HomeActivity.class);
                             startActivity(intent);

--- a/app/src/main/java/com/project/togather/user/SignUpActivity.java
+++ b/app/src/main/java/com/project/togather/user/SignUpActivity.java
@@ -228,7 +228,7 @@ public class SignUpActivity extends AppCompatActivity {
                     Boolean isUserNameAvailable = response.body();
                     // 중복된 유저 이름으로 가입 시도시
                     if (isUserNameAvailable != null && isUserNameAvailable) {
-                        new ToastWarning("이미 존재하는 유저 이름입니다.", SignUpActivity.this);
+                        new ToastWarning("이미 사용 중인 이름이에요", SignUpActivity.this);
                         return;
                     }
 
@@ -239,7 +239,7 @@ public class SignUpActivity extends AppCompatActivity {
                         public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
                             if (response.isSuccessful()) {
                                 // 회원가입 성공 후 로그인 시도
-                                new ToastSuccess("회원가입 완료", SignUpActivity.this);
+                                new ToastSuccess("가입이 완료되었어요", SignUpActivity.this);
                                 performLogin(phoneNumber);
                                 return ;
                             }

--- a/app/src/main/java/com/project/togather/utils/TokenManager.java
+++ b/app/src/main/java/com/project/togather/utils/TokenManager.java
@@ -31,18 +31,16 @@ public class TokenManager {
     }
 
     public void saveUserInfo(JSONObject jsonObject) {
-        String userId = jsonObject.optString("_id");
-        String email = jsonObject.optString("email");
-        String username = jsonObject.optString("username");
-        String role = jsonObject.optString("role");
-        int point = jsonObject.optInt("point");
+        String userId = jsonObject.optString("id");
+        String phone = jsonObject.optString("phone");
+        String username = jsonObject.optString("name");
+        String photo = jsonObject.optString("photo");
 
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putString("userId`", userId);
-        editor.putString("email", email);
-        editor.putString("username", username);
-        editor.putString("role", role);
-        editor.putInt("point", point);
+        editor.putString("id", userId);
+        editor.putString("phone", phone);
+        editor.putString("name", username);
+        editor.putString("photo", photo);
         editor.apply();
     }
 
@@ -51,29 +49,27 @@ public class TokenManager {
         // 토큰 제거
         editor.remove("JWT_TOKEN");
         // 사용자 정보 제거
-//        editor.remove("userId");
-//        editor.remove("email");
-//        editor.remove("username");
-//        editor.remove("role");
-//        editor.remove("point");
+        editor.remove("id");
+        editor.remove("phone");
+        editor.remove("name");
+        editor.remove("photo");
         editor.apply();
     }
 
     public String getUserId() {
-        return prefs.getString("userId", null);
+        return prefs.getString("id", null);
     }
 
-    public String getEmail() {
-        return prefs.getString("email", null);
+    public String getPhone() {
+        return prefs.getString("phone", null);
     }
 
     public String getUsername() {
-        return prefs.getString("username", null);
+        return prefs.getString("name", null);
     }
 
-    public String getRole() {
-        return prefs.getString("role", null);
+    public String getPhoto() {
+        return prefs.getString("photo", null);
     }
 
-    public int getPoint() { return prefs.getInt("point", 0); }
 }

--- a/app/src/main/res/layout/activity_edit_my_profile.xml
+++ b/app/src/main/res/layout/activity_edit_my_profile.xml
@@ -73,7 +73,7 @@
                     android:layout_width="125dp"
                     android:layout_height="125dp"
                     android:scaleType="centerCrop"
-                    android:src="@drawable/user_profile_image_temp_image_1"
+                    android:src="@drawable/one_person_logo"
                     app:riv_oval="true" />
 
                 <com.makeramen.roundedimageview.RoundedImageView
@@ -112,7 +112,7 @@
                     android:hint="닉네임을 입력해 주세요."
                     android:maxLength="12"
                     android:paddingHorizontal="15dp"
-                    android:text="김감자"
+                    android:text=""
                     android:textColorHint="@color/hint_color"
                     android:textSize="17.5sp" />
 

--- a/app/src/main/res/layout/activity_profile.xml
+++ b/app/src/main/res/layout/activity_profile.xml
@@ -78,16 +78,17 @@
                             android:layout_marginEnd="0dp"
                             android:layout_marginBottom="0dp"
                             android:scaleType="centerCrop"
-                            android:src="@drawable/user_profile_image_temp_image_1"
+                            android:src="@drawable/one_person_logo"
                             app:riv_oval="true" />
 
                         <TextView
+                            android:id="@+id/userName_textView"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
                             android:layout_marginLeft="12.5dp"
                             android:layout_toRightOf="@+id/userProfileImage_roundedImageView"
-                            android:text="김감자"
+                            android:text=""
                             android:textSize="20sp" />
                     </RelativeLayout>
 


### PR DESCRIPTION
## 👀 이슈

resolve #34 

## 📌 개요

JWT Token을 기반으로 회원 정보 삭제와 조회/수정 기능을 추가하고자 하였습니다.

## 👩‍💻 작업 사항

- 로그아웃 진행 시 `메인 액티비티`로 이동 및 토큰 값과 유저 정보를 비워줍니다.
- 현재 발급받은 토큰 값이 존재한다면 `메인 액티비티`에서 로그인 과정 생략하고 `홈 액티비티`로 이동할 수 있습니다.
- 로그인에 성공했을 경우 서버에서 유저 정보를 조회하여 sharedpreference를 활용하여 유저 정보를 저장 관리합니다.
- 전역으로 저장된 유저 정보를 `프로필 액티비티`에서 현재 유저이름, 프로필 사진을 반영하여 보여줍니다.
- `프로필 수정 액티비티`에서 유저 이름과 프로필 사진을 변경 할 수 있습니다.
- 

## ✅ 참고 사항
*중요 사항*
- 현재 프로필 사진은 변경하지 않고 유저 이름만 변경 불가능한 상태 서버에서 이미지를 null로 요청받을 때도 변경이 되게하거나 클라이언트에서 따로 처리해야할 것 같습니다.
- 프로필 수정 성공 후 finish()로 `프로필 수정 액티비티`를 종료합니다. 현재 유저 정보를 반영하여 액티비티에 보여주는 로직이 onCreate 됐을 때 유저 이름과 프로필 사진을 설정해주는 로직이라서 finish()로 종료 될 시에는 이전 액티비티가 새로 create되는 것이 아니라서 다른 액티비티에 갔다가 다시 돌아와야 적용되는 문제가 있습니다. 추후 수정하겠습니다.
- 서버와 통신이 제대로 이루어지지 않았을 때의 처리 코드 미구현

[Screen_recording_20240512_024727.webm](https://github.com/cbnu-togather/togather-client/assets/127587330/20bfc918-af8e-4ba7-8e77-e259d556226c)

