### PR TITLE
[feat]: 홈 액티비티 모집글 리스트 조회 기능 추가

### DIFF
--- a/app/src/main/java/com/project/togather/GetMyLocation.java
+++ b/app/src/main/java/com/project/togather/GetMyLocation.java
@@ -46,7 +46,7 @@ public class GetMyLocation {
                             1000);
                 }
             }
-//            getMyLocation(); //이건 써도되고 안써도 되지만, 전 권한 승인하면 즉시 위치값 받아오려고 썼습니다!
+            getMyLocation(); //이건 써도되고 안써도 되지만, 전 권한 승인하면 즉시 위치값 받아오려고 썼습니다!
         } else {
             System.out.println("//////////// 권한 요청 안해도 됨");
 

--- a/app/src/main/java/com/project/togather/chat/ChatActivity.java
+++ b/app/src/main/java/com/project/togather/chat/ChatActivity.java
@@ -24,6 +24,7 @@ import com.project.togather.MainActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.R;
 import com.project.togather.createPost.recruitment.CreateRecruitmentPostActivity;
+import com.project.togather.createPost.recruitment.SelectMeetingSpotActivity;
 import com.project.togather.notification.NotificationActivity;
 import com.project.togather.profile.ProfileActivity;
 import com.project.togather.community.CommunityActivity;
@@ -36,14 +37,24 @@ import java.util.Date;
 import java.util.Locale;
 
 import com.project.togather.databinding.ActivityChatBinding;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
+import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class ChatActivity extends AppCompatActivity {
 
     private ActivityChatBinding binding;
 
     private RecyclerViewAdapter adapter;
+    private UserAPI userAPI;
     private TokenManager tokenManager;
+    private RetrofitService retrofitService;
     private final OnBackPressedDispatcher onBackPressedDispatcher = getOnBackPressedDispatcher();
 
     private BottomSheetBehavior selectCreatePostTypeBottomSheetBehavior;
@@ -55,6 +66,8 @@ public class ChatActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         // 토큰 값이 없다면 메인 액티비티로 이동
         if (tokenManager.getToken() == null) {
@@ -428,5 +441,29 @@ public class ChatActivity extends AppCompatActivity {
                 return isSameDay(cal1, cal2);
             }
         }
+    }
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(ChatActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), ChatActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/community/CreateCommunityPostActivity.java
@@ -25,17 +25,25 @@ import com.project.togather.R;
 import com.project.togather.chat.ChatDetailInfoItem;
 import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.databinding.ActivityCreateCommunityPostBinding;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastSuccess;
 import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
 public class CreateCommunityPostActivity extends AppCompatActivity {
 
     private ActivityCreateCommunityPostBinding binding;
     private TokenManager tokenManager;
-
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
     private BottomSheetBehavior selectCategoryBottomSheetBehavior;
 
     private static final int REQUEST_GALLERY = 2;
@@ -48,13 +56,10 @@ public class CreateCommunityPostActivity extends AppCompatActivity {
         binding = ActivityCreateCommunityPostBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        tokenManager = TokenManager.getInstance(this);
 
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(CreateCommunityPostActivity.this, MainActivity.class));
-            finish();
-        }
+        tokenManager = TokenManager.getInstance(this);
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         selectedImageUri = Uri.parse("");
 
@@ -548,5 +553,29 @@ public class CreateCommunityPostActivity extends AppCompatActivity {
                     break;
             }
         }
+    }
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(CreateCommunityPostActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), CreateCommunityPostActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/CreateRecruitmentPostActivity.java
@@ -29,8 +29,10 @@ import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivityCreateRecruitmentPostBinding;
 import com.project.togather.home.RecruitmentPostDetailActivity;
 import com.project.togather.profile.EditMyProfile;
+import com.project.togather.profile.ProfileActivity;
 import com.project.togather.retrofit.RetrofitService;
 import com.project.togather.retrofit.interfaceAPI.RecruitmentAPI;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastSuccess;
 import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
@@ -40,6 +42,7 @@ import org.json.JSONObject;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.UUID;
@@ -55,7 +58,9 @@ import retrofit2.Response;
 public class CreateRecruitmentPostActivity extends AppCompatActivity {
 
     private ActivityCreateRecruitmentPostBinding binding;
+
     private TokenManager tokenManager;
+    private UserAPI userAPI;
     private RecruitmentAPI recruitmentAPI;
     private RetrofitService retrofitService;
     private BottomSheetBehavior selectFoodCategoryBottomSheetBehavior;
@@ -77,6 +82,7 @@ public class CreateRecruitmentPostActivity extends AppCompatActivity {
         tokenManager = TokenManager.getInstance(this);
         retrofitService = new RetrofitService(tokenManager);
         recruitmentAPI = retrofitService.getRetrofit().create(RecruitmentAPI.class);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         selectedImageUri = Uri.parse("");
 
@@ -551,16 +557,30 @@ public class CreateRecruitmentPostActivity extends AppCompatActivity {
 
     }
 
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(CreateRecruitmentPostActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), CreateRecruitmentPostActivity.this);
+            }
+        });
+    }
+
     // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
     @Override
     public void onResume() {
         super.onResume();
 
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(CreateRecruitmentPostActivity.this, MainActivity.class));
-            finish();
-        }
+        getUserInfo();
 
         SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE);
         sp_extractedDong = sharedPreferences.getString("extractedDong", "");

--- a/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
@@ -169,8 +169,8 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
         GetMyLocation getMyLocation = new GetMyLocation(this, this);
         Location userLocation = getMyLocation.getMyLocation();
         if (userLocation != null) {
-            currLatitude = 36.62565323814696; // 소프트웨어학부 건물 위도, 경도
-            currLongitude = 127.45428323069932;
+            currLatitude = userLocation.getLatitude(); // 소프트웨어학부 건물 위도, 경도
+            currLongitude = userLocation.getLongitude();
             System.out.println("////////////현재 내 위치값 : " + currLatitude + "," + currLongitude);
             currPoint = MapPoint.mapPointWithGeoCoord(currLatitude, currLongitude);
 

--- a/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
+++ b/app/src/main/java/com/project/togather/createPost/recruitment/SelectMeetingSpotActivity.java
@@ -46,8 +46,10 @@ import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivitySelectMeetingSpotBinding;
 import com.project.togather.home.HomeActivity;
 import com.project.togather.model.CoordinateToAddress;
+import com.project.togather.retrofit.RetrofitService;
 import com.project.togather.retrofit.RetrofitServiceForKakao;
 import com.project.togather.retrofit.interfaceAPI.KakaoAPI;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
@@ -57,6 +59,7 @@ import net.daum.mf.map.api.MapPoint;
 
 import java.util.List;
 
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
@@ -65,6 +68,8 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
 
     private ActivitySelectMeetingSpotBinding binding;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
 
     /**
      * 위치 권한 요청 코드의 상숫값
@@ -122,12 +127,8 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(SelectMeetingSpotActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         // 전역 데이터 로드
         SharedPreferences sharedPreferences = getApplicationContext().getSharedPreferences("AppPreferences", Context.MODE_PRIVATE);
@@ -383,6 +384,32 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
         });
     }
 
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(SelectMeetingSpotActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), SelectMeetingSpotActivity.this);
+            }
+        });
+    }
+
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
+    }
+
     public void resolveLocationSettings(Exception exception) {
         ResolvableApiException resolvable = (ResolvableApiException) exception;
         try {
@@ -484,4 +511,5 @@ public class SelectMeetingSpotActivity extends AppCompatActivity implements net.
     public void onDraggablePOIItemMoved(MapView mapView, MapPOIItem mapPOIItem, MapPoint
             mapPoint) {
     }
+
 }

--- a/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostActivity.java
@@ -30,15 +30,24 @@ import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.createPost.community.CreateCommunityPostActivity;
 import com.project.togather.databinding.ActivityCommunityPostDetailBinding;
 import com.project.togather.databinding.ActivityEditCommunityPostBinding;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
 
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
 public class EditCommunityPostActivity extends AppCompatActivity {
 
     private ActivityEditCommunityPostBinding binding;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
     private BottomSheetBehavior selectCategoryBottomSheetBehavior;
 
     private static final int REQUEST_GALLERY = 2;
@@ -52,12 +61,8 @@ public class EditCommunityPostActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(EditCommunityPostActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         // X 이미지뷰 클릭 시 현재 액티비티 종료
         binding.closeActivityImageView.setOnClickListener(view -> finish());
@@ -608,5 +613,29 @@ public class EditCommunityPostActivity extends AppCompatActivity {
                     break;
             }
         }
+    }
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(EditCommunityPostActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), EditCommunityPostActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostCommentActivity.java
+++ b/app/src/main/java/com/project/togather/editPost/community/EditCommunityPostCommentActivity.java
@@ -23,15 +23,25 @@ import com.bumptech.glide.Glide;
 import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityEditCommunityPostCommentBinding;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
 import java.io.InputStream;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class EditCommunityPostCommentActivity extends AppCompatActivity {
 
     private ActivityEditCommunityPostCommentBinding binding;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
 
     private static Dialog askCancelWriteComment_dialog;
 
@@ -46,12 +56,8 @@ public class EditCommunityPostCommentActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(EditCommunityPostCommentActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         selectedImageUri = Uri.parse("");
 
@@ -186,5 +192,29 @@ public class EditCommunityPostCommentActivity extends AppCompatActivity {
             askCancelWriteComment_dialog.dismiss(); // 다이얼로그 닫기
             finish();
         });
+    }
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(EditCommunityPostCommentActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), EditCommunityPostCommentActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/home/HomeActivity.java
+++ b/app/src/main/java/com/project/togather/home/HomeActivity.java
@@ -205,12 +205,15 @@ public class HomeActivity extends AppCompatActivity {
         binding.postsRecyclerView.setAdapter(adapter);
         binding.postsRecyclerView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
 
+
+
         binding.swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
                 refreshData(); // 데이터 새로고침 메소드 호출
             }
         });
+
 
         // 초기 데이터 로드
         loadData();
@@ -742,6 +745,7 @@ public class HomeActivity extends AppCompatActivity {
         adapter.setPostInfoList(filteredItems); // 필터링된 리스트를 리사이클러 뷰에 설정
         binding.postsRecyclerView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
         binding.postsRecyclerView.setAdapter(adapter); // 어댑터를 다시 설정하여 갱신
+
     }
 
     // 데이터 새로고침 함수
@@ -763,7 +767,7 @@ public class HomeActivity extends AppCompatActivity {
 
     // 데이터 로딩 함수
     private void loadData() {
-        Call<ResponseBody> call = recruitmentAPI.getRecruitmentPostList(33, 35);
+        Call<ResponseBody> call = recruitmentAPI.getRecruitmentPostList(currLatitude, currLongitude);
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
@@ -797,7 +801,8 @@ public class HomeActivity extends AppCompatActivity {
                                         post.getLikes()
                                 );
                                 Log.d("elapsedTime", "onResponse: " + elapsedTime);
-                                postInfoItems.add(item);
+                                postInfoItems.add(0, item);
+
                             } catch (ParseException e) {
                                 e.printStackTrace();
                                 Log.e("ParseException", "Date parsing error for post: " + post.getCreatedAt(), e);
@@ -817,6 +822,7 @@ public class HomeActivity extends AppCompatActivity {
                 new ToastWarning(getResources().getString(R.string.toast_server_error), HomeActivity.this);
             }
         });
+
     }
 
     private void requestPermissions() {
@@ -868,15 +874,5 @@ public class HomeActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(HomeActivity.this, MainActivity.class));
-            finish();
-        }
-
-
-
-
     }
 }

--- a/app/src/main/java/com/project/togather/home/PostInfoItem.java
+++ b/app/src/main/java/com/project/togather/home/PostInfoItem.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class PostInfoItem {
+    private int id;
     private String postThumbnailImageUrl;
     private String title;
     private String category;

--- a/app/src/main/java/com/project/togather/home/PostInfoResponse.java
+++ b/app/src/main/java/com/project/togather/home/PostInfoResponse.java
@@ -1,0 +1,20 @@
+package com.project.togather.home;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PostInfoResponse {
+    private int id;
+    private String title;
+    private String img;
+    private String createdAt;
+    private int headCount;
+    private int currentCount;
+    private int likes;
+    private String category;
+    private boolean liked;
+}

--- a/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
+++ b/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
@@ -24,7 +24,11 @@ import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityRecruitmentPostDetailBinding;
 import com.project.togather.editPost.recruitment.EditRecruitmentPostActivity;
+import com.project.togather.editPost.recruitment.EditRecruitmentPostSelectMeetingSpotActivity;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
 import com.project.togather.toast.ToastSuccess;
+import com.project.togather.toast.ToastWarning;
 import com.project.togather.user.LoginActivity;
 import com.project.togather.utils.TokenManager;
 
@@ -32,12 +36,19 @@ import net.daum.mf.map.api.MapPOIItem;
 import net.daum.mf.map.api.MapPoint;
 import net.daum.mf.map.api.MapView;
 
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
 public class RecruitmentPostDetailActivity extends AppCompatActivity {
 
     private ActivityRecruitmentPostDetailBinding binding;
 
     private BottomSheetBehavior selectPostManagementBottomSheetBehavior;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
     private Dialog askDeletePost_dialog, askJoinParty_dialog, askStopRecruitment_dialog;
 
     private boolean isWriter, isLiked, isRecruitmentComplete;
@@ -60,12 +71,8 @@ public class RecruitmentPostDetailActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(RecruitmentPostDetailActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         binding.activityHeaderRelativeLayout.bringToFront();
 
@@ -267,9 +274,29 @@ public class RecruitmentPostDetailActivity extends AppCompatActivity {
         binding.functionButton.setEnabled(isRecruitmentComplete ? false : true);
     }
 
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(RecruitmentPostDetailActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), RecruitmentPostDetailActivity.this);
+            }
+        });
+    }
+
     @Override
     protected void onResume() {
         super.onResume();
+
+        getUserInfo();
 
         /** 다음 카카오맵 지도를 띄우는 코드 */
         mapView = new MapView(this);

--- a/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
+++ b/app/src/main/java/com/project/togather/home/RecruitmentPostDetailActivity.java
@@ -74,6 +74,9 @@ public class RecruitmentPostDetailActivity extends AppCompatActivity {
         retrofitService = new RetrofitService(tokenManager);
         userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
+        Intent intent = getIntent();
+        String postId = intent.getStringExtra("post_id");
+
         binding.activityHeaderRelativeLayout.bringToFront();
 
         /** (게시글 삭제 확인) 다이얼로그 변수 초기화 및 설정 */

--- a/app/src/main/java/com/project/togather/profile/EditMyProfile.java
+++ b/app/src/main/java/com/project/togather/profile/EditMyProfile.java
@@ -81,8 +81,6 @@ public class EditMyProfile extends AppCompatActivity {
         retrofitService = new RetrofitService(tokenManager);
         userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
-        getUserInfo();
-
         setupListeners();
     }
 
@@ -113,6 +111,9 @@ public class EditMyProfile extends AppCompatActivity {
                     } catch (IOException | JSONException e) {
                         e.printStackTrace();
                     }
+                } else if (response.code() == 403) {
+                    startActivity(new Intent(EditMyProfile.this, MainActivity.class));
+                    finish();
                 }
             }
 
@@ -259,14 +260,13 @@ public class EditMyProfile extends AppCompatActivity {
         binding.usernameEditTextHelperTextView.setText(!isValid && input.length() < 2 ? "닉네임은 2자 이상 입력해 주세요." : "닉네임은 띄어쓰기 없이 한글, 영문, 숫자만 가능해요.");
     }
 
+
+
     @Override
     protected void onResume() {
         super.onResume();
 
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(EditMyProfile.this, MainActivity.class));
-            finish();
-        }
+        // 유저 정보 조회 후 토큰 값의 유효성 따라 다르게 작동
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -280,6 +280,9 @@ public class ProfileActivity extends AppCompatActivity {
                     } catch (IOException | JSONException e) {
                         e.printStackTrace();
                     }
+                } else if (response.code() == 403) {
+                    startActivity(new Intent(ProfileActivity.this, MainActivity.class));
+                    finish();
                 }
             }
 
@@ -294,11 +297,6 @@ public class ProfileActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
 
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(ProfileActivity.this, MainActivity.class));
-            finish();
-        }
         getUserInfo();
 
     }

--- a/app/src/main/java/com/project/togather/profile/ProfileActivity.java
+++ b/app/src/main/java/com/project/togather/profile/ProfileActivity.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.Window;
 import android.widget.Button;
@@ -264,20 +265,27 @@ public class ProfileActivity extends AppCompatActivity {
                         String responseBodyString = response.body().string();
                         JSONObject jsonObject = new JSONObject(responseBodyString);
 
-                        String userName = jsonObject.getString("name");
-                        String photo = jsonObject.getString("photo");
+                        // JSON 필드 존재 여부 확인
+                        if (jsonObject.has("name") && jsonObject.has("photo")) {
+                            String userName = jsonObject.getString("name");
+                            String photo = jsonObject.getString("photo");
 
-                        // 내 유저 이름을 표시
-                        binding.userNameTextView.setText(userName);
+                            // 내 유저 이름을 표시
+                            binding.userNameTextView.setText(userName);
 
-                        // 내 프로필 사진을 표시
-                        Glide.with(ProfileActivity.this)
-                                .load(photo)
-                                .placeholder(R.drawable.one_person_logo)
-                                .error(R.drawable.one_person_logo)
-                                .into(binding.userProfileImageRoundedImageView);
-
-                    } catch (IOException | JSONException e) {
+                            // 내 프로필 사진을 표시
+                            Glide.with(ProfileActivity.this)
+                                    .load(photo)
+                                    .placeholder(R.drawable.one_person_logo)
+                                    .error(R.drawable.one_person_logo)
+                                    .into(binding.userProfileImageRoundedImageView);
+                        } else {
+                            // 필요한 필드가 없을 경우 로그 출력
+                            Log.e("getUserInfo", "Required fields are missing in the JSON response.");
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    } catch (JSONException e) {
                         e.printStackTrace();
                     }
                 } else if (response.code() == 403) {

--- a/app/src/main/java/com/project/togather/profile/myCommunityPost/MyCommunityPostListActivity.java
+++ b/app/src/main/java/com/project/togather/profile/myCommunityPost/MyCommunityPostListActivity.java
@@ -23,14 +23,25 @@ import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.community.CommunityPostDetailActivity;
 import com.project.togather.databinding.ActivityMyCommunityPostListBinding;
+import com.project.togather.editPost.recruitment.EditRecruitmentPostSelectMeetingSpotActivity;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
+import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class MyCommunityPostListActivity extends AppCompatActivity {
 
     private ActivityMyCommunityPostListBinding binding;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
 
     private RecyclerViewAdapter adapter;
 
@@ -41,12 +52,8 @@ public class MyCommunityPostListActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(MyCommunityPostListActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         adapter = new RecyclerViewAdapter();
 
@@ -338,5 +345,29 @@ public class MyCommunityPostListActivity extends AppCompatActivity {
                 likedCnt_textView.setText("" + item.getLikedCnt());
             }
         }
+    }
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(MyCommunityPostListActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), MyCommunityPostListActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/profile/myRecruitmentPartyPost/MyRecruitmentPartyPostListActivity.java
+++ b/app/src/main/java/com/project/togather/profile/myRecruitmentPartyPost/MyRecruitmentPartyPostListActivity.java
@@ -22,15 +22,26 @@ import com.bumptech.glide.Glide;
 import com.project.togather.MainActivity;
 import com.project.togather.R;
 import com.project.togather.databinding.ActivityMyRecruitmentPartyListBinding;
+import com.project.togather.editPost.recruitment.EditRecruitmentPostSelectMeetingSpotActivity;
 import com.project.togather.home.RecruitmentPostDetailActivity;
+import com.project.togather.retrofit.RetrofitService;
+import com.project.togather.retrofit.interfaceAPI.UserAPI;
+import com.project.togather.toast.ToastWarning;
 import com.project.togather.utils.TokenManager;
 
 import java.util.ArrayList;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 public class MyRecruitmentPartyPostListActivity extends AppCompatActivity {
 
     private ActivityMyRecruitmentPartyListBinding binding;
     private TokenManager tokenManager;
+    private UserAPI userAPI;
+    private RetrofitService retrofitService;
 
     private RecyclerViewAdapter adapter;
 
@@ -41,12 +52,8 @@ public class MyRecruitmentPartyPostListActivity extends AppCompatActivity {
         setContentView(binding.getRoot());
 
         tokenManager = TokenManager.getInstance(this);
-
-        // 토큰 값이 없다면 메인 액티비티로 이동
-        if (tokenManager.getToken() == null) {
-            startActivity(new Intent(MyRecruitmentPartyPostListActivity.this, MainActivity.class));
-            finish();
-        }
+        retrofitService = new RetrofitService(tokenManager);
+        userAPI = retrofitService.getRetrofit().create(UserAPI.class);
 
         adapter = new RecyclerViewAdapter();
 
@@ -296,5 +303,30 @@ public class MyRecruitmentPartyPostListActivity extends AppCompatActivity {
             }
         }
 
+    }
+
+    // 유저 정보 조회 메서드
+    private void getUserInfo() {
+        Call<ResponseBody> call = userAPI.getUserInfo();
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.code() == 403) {
+                    startActivity(new Intent(MyRecruitmentPartyPostListActivity.this, MainActivity.class));
+                    finish();
+                }
+            }
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable throwable) {
+                new ToastWarning(getResources().getString(R.string.toast_server_error), MyRecruitmentPartyPostListActivity.this);
+            }
+        });
+    }
+    // 이 액티비티로 다시 돌아왔을 때 실행되는 메소드
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        getUserInfo();
     }
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/RecruitmentAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/RecruitmentAPI.java
@@ -5,6 +5,7 @@ import androidx.annotation.Nullable;
 import okhttp3.MultipartBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
+import retrofit2.http.GET;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
@@ -34,6 +35,12 @@ public interface RecruitmentAPI {
             @Query("address") String address,
             @Query("spotName") String spotName,
             @Query("category") String category
+    );
+
+    @GET("groupbuy/list")
+    Call<ResponseBody> getRecruitmentPostList(
+            @Query("Latitude") double latitude,
+            @Query("Longitude") double longitude
     );
 
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/RecruitmentAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/RecruitmentAPI.java
@@ -40,7 +40,8 @@ public interface RecruitmentAPI {
     @GET("groupbuy/list")
     Call<ResponseBody> getRecruitmentPostList(
             @Query("Latitude") double latitude,
-            @Query("Longitude") double longitude
+            @Query("Longitude") double longitude,
+            @Query("distance") int distance
     );
 
 }

--- a/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
+++ b/app/src/main/java/com/project/togather/retrofit/interfaceAPI/UserAPI.java
@@ -16,16 +16,17 @@ import retrofit2.http.Query;
 
 public interface UserAPI {
     @GET("/user/phone")
-    Call<ResponseBody> checkPhoneNumber(@Query("phone") String phone);
+    Call<ResponseBody> checkPhoneNumber(@Header("Authorization-Type") String authType, @Query("phone") String phone);
     @GET("/user/doublecheck")
-    Call<Boolean> doubleCheckUserName(@Query("name") String name);
+    Call<Boolean> doubleCheckUserName(@Header("Authorization-Type") String authType, @Query("name") String name);
     @POST("/user")
     Call<ResponseBody> signUp(
+            @Header("Authorization-Type") String authType,
             @Query("phone") String phone,
             @Query("name") String name
     );
     @POST("/login")
-    Call<ResponseBody> login(@Query("phone") String phone);
+    Call<ResponseBody> login(@Header("Authorization-Type") String authType, @Query("phone") String phone);
     @DELETE("/user")
     @Headers("accept: application/json")
     Call<Void> deleteUser();

--- a/app/src/main/java/com/project/togather/user/SignUpActivity.java
+++ b/app/src/main/java/com/project/togather/user/SignUpActivity.java
@@ -171,7 +171,7 @@ public class SignUpActivity extends AppCompatActivity {
 
     // 로그인 메서드
     private void performLogin(String phoneNumber) {
-        Call<ResponseBody> call = userAPI.login(phoneNumber);
+        Call<ResponseBody> call = userAPI.login("no-auth", phoneNumber);
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
@@ -220,7 +220,7 @@ public class SignUpActivity extends AppCompatActivity {
         String phoneNumber = binding.phoneNumberEditText.getText().toString().replaceAll("\\s", "");
 
         // 닉네임 중복 확인
-        Call<Boolean> doubleCheckCall = userAPI.doubleCheckUserName(username);
+        Call<Boolean> doubleCheckCall = userAPI.doubleCheckUserName("no-auth", username);
         doubleCheckCall.enqueue(new Callback<Boolean>() {
             @Override
             public void onResponse(Call<Boolean> call, Response<Boolean> response) {
@@ -233,7 +233,7 @@ public class SignUpActivity extends AppCompatActivity {
                     }
 
                     // 중복되지 않은 경우 회원 가입
-                    Call<ResponseBody> signUpCall = userAPI.signUp(phoneNumber, username);
+                    Call<ResponseBody> signUpCall = userAPI.signUp("no-auth", phoneNumber, username);
                     signUpCall.enqueue(new Callback<ResponseBody>() {
                         @Override
                         public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {

--- a/app/src/main/java/com/project/togather/utils/AuthInterceptor.java
+++ b/app/src/main/java/com/project/togather/utils/AuthInterceptor.java
@@ -20,13 +20,15 @@ public class AuthInterceptor implements Interceptor {
     @Override
     public Response intercept(@NotNull Chain chain) throws IOException {
         Request request = chain.request();
-        Request newRequest;
+        Request.Builder requestBuilder = request.newBuilder();
 
-        String token = tokenManager.getToken();
-        newRequest = request.newBuilder()
-                .addHeader("Authorization", "Bearer " + token)
-                .build();
+        if (!"no-auth".equals(request.header("Authorization-Type"))) {
+            String token = tokenManager.getToken();
+            requestBuilder.addHeader("Authorization", "Bearer " + token);
+        }
 
-        return chain.proceed(newRequest);
+        requestBuilder.removeHeader("Authorization-Type");
+
+        return chain.proceed(requestBuilder.build());
     }
 }


### PR DESCRIPTION
## 👀 이슈

resolve #38 

## 📌 개요

`홈 액티비티`에서 등록한 파티원 모집글 리스트를 리사이클러 뷰에 표시하도록 하였습니다.

## 👩‍💻 작업 사항

- 등록한 모집글 리스트 표시 기능
- 설정한 거리에 따라 위치 기반으로 리스트 표시 기능
- 리스트 새로고침 기능 추가
- 기존 유저 API에서 토큰 값이 필요없는 API의 경우 AuthInterceptor에 의해 토큰을 자동으로 헤더 전송하지 않게 수정

## ✅ 참고 사항


https://github.com/cbnu-togather/togather-client/assets/127587330/7ba5e0b9-3c4b-4779-a043-aea81565571a

